### PR TITLE
When there are no suggestions the SearchView does not cover the underlaying layout.

### DIFF
--- a/library/src/main/java/com/miguelcatalan/materialsearchview/MaterialSearchView.java
+++ b/library/src/main/java/com/miguelcatalan/materialsearchview/MaterialSearchView.java
@@ -393,6 +393,7 @@ public class MaterialSearchView extends FrameLayout implements Filter.FilterList
      */
     public void setSuggestions(String[] suggestions) {
         if (suggestions != null && suggestions.length > 0) {
+            mTintView.setVisibility(VISIBLE);
             final SearchAdapter adapter = new SearchAdapter(mContext, suggestions, suggestionIcon);
             setAdapter(adapter);
 
@@ -402,6 +403,8 @@ public class MaterialSearchView extends FrameLayout implements Filter.FilterList
                     setQuery((String) adapter.getItem(position), false);
                 }
             });
+        } else {
+            mTintView.setVisibility(GONE);
         }
     }
 

--- a/library/src/main/res/layout/search_view.xml
+++ b/library/src/main/res/layout/search_view.xml
@@ -9,7 +9,8 @@
         android:id="@+id/transparent_view"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:background="@color/search_layover_bg" />
+        android:background="@color/search_layover_bg"
+        android:visibility="gone" />
 
     <LinearLayout
         android:layout_width="match_parent"


### PR DESCRIPTION
Only when there are suggestions for the search view, the background will be shown. This allows to show the layout behind it to show results. 

From https://github.com/MiguelCatalan/MaterialSearchView/issues/11