### PR TITLE
Add ability to set different text size

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,9 @@ http://www.materialdoc.com/search-filter/
 
         <!-- Change background for the suggestions list view -->
         <item name="searchSuggestionBackground">@android:color/white</item>
+        
+        <!-- Change text size for edit text -->
+        <item name="android:textSize">@dimen/text_size_in_sp</item>
 
         <!-- Change text color for edit text. This will also be the color of the cursor -->
         <item name="android:textColor">@color/theme_primary_text_inverted</item>

--- a/library/src/main/java/com/miguelcatalan/materialsearchview/MaterialSearchView.java
+++ b/library/src/main/java/com/miguelcatalan/materialsearchview/MaterialSearchView.java
@@ -17,6 +17,7 @@ import android.text.TextUtils;
 import android.text.TextWatcher;
 import android.util.AttributeSet;
 import android.util.Log;
+import android.util.TypedValue;
 import android.view.KeyEvent;
 import android.view.LayoutInflater;
 import android.view.MenuItem;
@@ -101,6 +102,10 @@ public class MaterialSearchView extends FrameLayout implements Filter.FilterList
         if (a != null) {
             if (a.hasValue(R.styleable.MaterialSearchView_searchBackground)) {
                 setBackground(a.getDrawable(R.styleable.MaterialSearchView_searchBackground));
+            }
+
+            if (a.hasValue(R.styleable.MaterialSearchView_android_textSize)) {
+                setTextSize(a.getDimensionPixelSize(R.styleable.MaterialSearchView_android_textSize, 0));
             }
 
             if (a.hasValue(R.styleable.MaterialSearchView_android_textColor)) {
@@ -305,6 +310,10 @@ public class MaterialSearchView extends FrameLayout implements Filter.FilterList
     @Override
     public void setBackgroundColor(int color) {
         mSearchTopBar.setBackgroundColor(color);
+    }
+
+    public void setTextSize(int size) {
+        mSearchSrcTextView.setTextSize(TypedValue.COMPLEX_UNIT_PX, size);
     }
 
     public void setTextColor(int color) {

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -8,6 +8,7 @@
         <attr name="searchSuggestionIcon" format="integer" />
         <attr name="searchSuggestionBackground" format="integer" />
         <attr name="android:hint" />
+        <attr name="android:textSize" />
         <attr name="android:textColor" />
         <attr name="android:textColorHint" />
     </declare-styleable>


### PR DESCRIPTION
This is working for my use case. I'm able to set 
`<item name="android:textSize">@dimen/font_size_toolbar</item>` where font_size_toolbar is 20sp.

I was hesitating to make a variable for `DEFAULT_TEXT_SIZE` in `MaterialSearchView.java`
e.g.:
`public static final int DEFAULT_TEXT_SIZE = 15;` 
then we can do:
`setTextSize(a.getDimensionPixelSize(R.styleable.MaterialSearchView_android_textSize, DEFAULT_TEXT_SIZE));`

But tbh, i'm not sure if it's needed.
