### PR TITLE
isVoiceAvailable() should return true if there are activities available to handle a voice search

### DIFF
--- a/library/src/main/java/com/miguelcatalan/materialsearchview/MaterialSearchView.java
+++ b/library/src/main/java/com/miguelcatalan/materialsearchview/MaterialSearchView.java
@@ -274,7 +274,7 @@ public class MaterialSearchView extends FrameLayout implements Filter.FilterList
         PackageManager pm = getContext().getPackageManager();
         List<ResolveInfo> activities = pm.queryIntentActivities(
                 new Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH), 0);
-        return activities.size() == 0;
+        return activities.size() > 0;
     }
 
     public void hideKeyboard(View view) {


### PR DESCRIPTION
Unless I'm missing something, shouldn't isVoiceAvailable() return true if the list of activities that can handle RecognizerIntent.ACTION_RECOGNIZE_SPEECH is greater than 0?  Is there a reason why it should return true if the list has 0 items?
